### PR TITLE
Refactor form logic and typing

### DIFF
--- a/app/HeartIcon.tsx
+++ b/app/HeartIcon.tsx
@@ -1,5 +1,13 @@
 import React from "react";
-export const HeartIcon:React.FC<any> = ({
+
+import { IconSvgProps } from "@/types";
+
+interface HeartIconProps extends IconSvgProps {
+  filled?: boolean;
+  label?: string;
+}
+
+export const HeartIcon: React.FC<HeartIconProps> = ({
   fill = "currentColor",
   filled,
   size,
@@ -10,19 +18,19 @@ export const HeartIcon:React.FC<any> = ({
 }) => {
   return (
     <svg
-      width={size || width || 24}
+      fill={filled ? fill : "none"}
       height={size || height || 24}
       viewBox="0 0 24 24"
-      fill={filled ? fill : "none"}
+      width={size || width || 24}
       xmlns="http://www.w3.org/2000/svg"
       {...props}
     >
       <path
         d="M12.62 20.81c-.34.12-.9.12-1.24 0C8.48 19.82 2 15.69 2 8.69 2 5.6 4.49 3.1 7.56 3.1c1.82 0 3.43.88 4.44 2.24a5.53 5.53 0 0 1 4.44-2.24C19.51 3.1 22 5.6 22 8.69c0 7-6.48 11.13-9.38 12.12Z"
         stroke={fill}
-        strokeWidth={1.5}
         strokeLinecap="round"
         strokeLinejoin="round"
+        strokeWidth={1.5}
       />
     </svg>
   );

--- a/app/board/page.tsx
+++ b/app/board/page.tsx
@@ -9,12 +9,11 @@ import {
   CardFooter,
   Divider,
   Link,
-  Image,
 } from "@nextui-org/react";
 import { useState, useEffect } from "react";
 import { db } from "../../config/firebase";
-import { collection, getDocs, addDoc } from "firebase/firestore";
-import { Mode } from "../page";
+import { collection, getDocs } from "firebase/firestore";
+import { Mode } from "@/hooks/useInboxForm";
 
 const modeToLabel = (mode: Mode) => {
   switch (mode) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,67 +1,18 @@
 "use client";
 import { Button } from "@nextui-org/button";
 import { Select, SelectItem } from "@nextui-org/select";
-import { useState } from "react";
-import { useFormik } from "formik";
-import { db } from "../config/firebase";
-import { collection, addDoc } from "firebase/firestore";
+
 import AdviceForm from "@/components/form/advice-form";
-
-export enum Mode {
-  "ADVICE" = "advice",
-  "FEEDBACK" = "feedback",
-  "SUGGESTION" = "suggestion",
-  "OTHER" = "other",
-  "TOPIC" = "topic",
-}
-
-const modeOptions = [
-  {
-    key: Mode.ADVICE,
-    label: "ขอคำปรึกษา",
-  },
-  {
-    key: Mode.TOPIC,
-    label: "อยากให้พูดคุยในหัวข้อ",
-  },
-];
+import { modeOptions, Mode, useInboxForm } from "@/hooks/useInboxForm";
 
 export default function Home() {
-  const [mode, setMode] = useState<Mode | undefined>(undefined);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const formik = useFormik({
-    initialValues: {
-      name: "",
-      age: 0,
-      message: "",
-    },
-    onSubmit: async (values) => {
-      try {
-        setLoading(true);
-        const docRef = collection(db, "inbox");
-        const res = await addDoc(docRef, {
-          name: values.name,
-          message: values.message,
-          mode: mode,
-        });
-        if (res.id) {
-          formik.resetForm();
-          console.log("Document written with ID: ", res.id);
-          alert(`ส่งข้อความเรียบร้อยแล้ว รหัส: ${res.id}`);
-        }
-      } catch (error) {
-        console.error("Error adding document: ", error);
-      }
-    },
-  });
+  const { formik, mode, setMode, loading } = useInboxForm();
 
   return (
     <section className="flex flex-col  justify-center gap-4 gap-y-6 py-8 md:py-10 text-left">
       <Select
-        label="ต้องการ ?"
         className="max-w-xs"
+        label="ต้องการ ?"
         labelPlacement="outside"
         onChange={(e) => setMode(e.target.value as Mode)}
       >
@@ -72,12 +23,12 @@ export default function Home() {
       {mode === Mode.ADVICE && <AdviceForm formik={formik} />}
       {mode !== undefined && (
         <Button
-          color="primary"
           className="w-full xl:max-w-[200px]"
+          color="primary"
+          disabled={loading}
           onPress={(e) => {
             formik.handleSubmit();
           }}
-          disabled={loading}
         >
           ส่งเลย
         </Button>

--- a/components/form/advice-form.tsx
+++ b/components/form/advice-form.tsx
@@ -1,72 +1,61 @@
 import { Input, Textarea } from "@nextui-org/input";
 import { Slider } from "@nextui-org/react";
-interface IAdviceFormProps {
-  formik: any;
+import { FormikProps } from "formik";
+
+import { InboxFormValues } from "@/hooks/useInboxForm";
+
+interface AdviceFormProps {
+  formik: FormikProps<InboxFormValues>;
 }
-const AdviceForm: React.FC<IAdviceFormProps> = ({ formik }) => {
+
+const marks = Array.from({ length: 5 }, (_, i) => ({
+  value: i + 1,
+  label: `${i + 1}`,
+}));
+
+const AdviceForm: React.FC<AdviceFormProps> = ({ formik }) => {
   return (
     <section className="flex flex-col gap-6">
       <div className="flex gap-x-6">
         <Input
           label="คุณคือใคร"
           labelPlacement="outside"
+          name="name"
           placeholder="ถ้าไม่ต้องการระบุชื่อผู้ส่งข้ามไปได้เลยย"
           type="text"
-          name="name"
-          onChange={formik.handleChange}
           value={formik.values.name}
+          onChange={formik.handleChange}
         />
         <Input
+          className="max-w-24"
           label="อายุ ?"
           labelPlacement="outside"
+          name="age"
           placeholder="ข้ามได้เหมือนกัน"
           type="number"
-          name="age"
-          onChange={formik.handleChange}
           value={formik.values.age}
-          className="max-w-24"
+          onChange={formik.handleChange}
         />
       </div>
       <Textarea
         isRequired
         label="ปัญหาที่ต้องการปรึกษา"
         labelPlacement="outside"
-        placeholder="อธิบายปัญหาที่ต้องการปรึกษา จะพิมพ์ยาวแค่ไหนก็ได้เลยย :)"
         name="message"
-        onChange={formik.handleChange}
+        placeholder="อธิบายปัญหาที่ต้องการปรึกษา จะพิมพ์ยาวแค่ไหนก็ได้เลยย :)"
         value={formik.values.message}
+        onChange={formik.handleChange}
       />
       <Slider
-        label="ความรู้สึกที่มีต่อปัญหานี้"
-        showTooltip={true}
-        step={1}
+        className="max-w-md"
+        defaultValue={0}
         formatOptions={{ style: "decimal" }}
+        label="ความรู้สึกที่มีต่อปัญหานี้"
+        marks={marks}
         maxValue={5}
         minValue={1}
-        marks={[
-          {
-            value: 1,
-            label: "1",
-          },
-          {
-            value: 2,
-            label: "2",
-          },
-          {
-            value: 3,
-            label: "3",
-          },
-          {
-            value: 4,
-            label: "4",
-          },
-          {
-            value: 5,
-            label: "5",
-          },
-        ]}
-        defaultValue={0}
-        className="max-w-md"
+        showTooltip={true}
+        step={1}
       />
       <p>
         1 = เฉยๆคิดว่าไม่กังวลมาก <br /> 2 = มีความกังวลเล็กน้อย <br /> 3 =

--- a/hooks/useInboxForm.ts
+++ b/hooks/useInboxForm.ts
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { useFormik, FormikProps } from "formik";
+import { collection, addDoc } from "firebase/firestore";
+
+import { db } from "@/config/firebase";
+
+export enum Mode {
+  ADVICE = "advice",
+  FEEDBACK = "feedback",
+  SUGGESTION = "suggestion",
+  OTHER = "other",
+  TOPIC = "topic",
+}
+
+export interface InboxFormValues {
+  name: string;
+  age: number;
+  message: string;
+}
+
+export const modeOptions = [
+  { key: Mode.ADVICE, label: "ขอคำปรึกษา" },
+  { key: Mode.TOPIC, label: "อยากให้พูดคุยในหัวข้อ" },
+];
+
+export const useInboxForm = () => {
+  const [mode, setMode] = useState<Mode | undefined>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const formik: FormikProps<InboxFormValues> = useFormik<InboxFormValues>({
+    initialValues: { name: "", age: 0, message: "" },
+    onSubmit: async (values, { resetForm }) => {
+      try {
+        setLoading(true);
+        const docRef = collection(db, "inbox");
+        const res = await addDoc(docRef, {
+          name: values.name,
+          message: values.message,
+          mode,
+        });
+
+        if (res.id) {
+          resetForm();
+          /* eslint-disable no-console */
+          console.log("Document written with ID: ", res.id);
+          alert(`ส่งข้อความเรียบร้อยแล้ว รหัส: ${res.id}`);
+        }
+      } catch (err) {
+        /* eslint-disable no-console */
+        console.error("Error adding document: ", err);
+        setError("Failed to send message.");
+      } finally {
+        setLoading(false);
+      }
+    },
+  });
+
+  return { formik, mode, setMode, loading, error };
+};


### PR DESCRIPTION
## Summary
- add `useInboxForm` hook for form logic
- type `HeartIcon` props
- clean up board imports
- refactor `AdviceForm` to use typed props
- update home page to use new hook

## Testing
- `npm run lint`