### PR TITLE
Add request music board

### DIFF
--- a/app/(board)/board-request-music/[slug]/page.tsx
+++ b/app/(board)/board-request-music/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+
+import BoardPostDetail from "@/components/board/board-post-detail";
+import { PostType } from "@/enums/post.enum";
+
+const RequestMusicPostDetailPage = ({ params }: { params: { slug: string } }) => {
+  return <BoardPostDetail params={params} type={PostType.REQUEST_MUSIC} />;
+};
+
+export default RequestMusicPostDetailPage;

--- a/app/(board)/board-request-music/page.tsx
+++ b/app/(board)/board-request-music/page.tsx
@@ -1,0 +1,8 @@
+import Board from "@/components/board/board";
+import { PostType } from "@/enums/post.enum";
+
+const BoardRequestMusic = () => {
+  return <Board type={PostType.REQUEST_MUSIC} />;
+};
+
+export default BoardRequestMusic;

--- a/components/board/board-post-detail.tsx
+++ b/components/board/board-post-detail.tsx
@@ -41,6 +41,8 @@ const getBoardDetailTitleByPostType = (type: PostType) => {
       return "หัวข้อ";
     case PostType.QA:
       return "คําถาม Q&A";
+    case PostType.REQUEST_MUSIC:
+      return "ขอเพลง";
     default:
       break;
   }
@@ -59,6 +61,10 @@ export const getPostStatusLabel = (type: PostType, status: PostStatus) => {
     [PostType.QA]: {
       [PostStatus.PENDING]: "ยังไม่ได้ตอบคําถาม",
       [PostStatus.DONE]: "ตอบคําถามแล้ว",
+    },
+    [PostType.REQUEST_MUSIC]: {
+      [PostStatus.PENDING]: "ยังไม่ได้เปิดเพลง",
+      [PostStatus.DONE]: "เปิดเพลงแล้ว",
     },
   };
 

--- a/components/board/board.tsx
+++ b/components/board/board.tsx
@@ -46,6 +46,8 @@ export const getCurrentBoardPathnameByType = (type: PostType) => {
       return "/board-topic";
     case PostType.QA:
       return "/board-qa";
+    case PostType.REQUEST_MUSIC:
+      return "/board-request-music";
     default:
       return "/home";
   }

--- a/components/form/request-music-form.tsx
+++ b/components/form/request-music-form.tsx
@@ -1,0 +1,134 @@
+import { Input } from "@heroui/input";
+import { Button } from "@heroui/button";
+import { Checkbox } from "@heroui/checkbox";
+import { Select, SelectItem } from "@heroui/select";
+import { CirclePicker } from "react-color";
+import { FormikProps } from "formik";
+
+import PostItCard from "../post-it-card";
+
+import { formOptions, postBackgroundColor } from "@/config/constants";
+
+interface IRequestMusicFormProps {
+  formik: FormikProps<any>;
+  isDetailPage?: boolean;
+  canEditPost?: boolean;
+  isLoadingSubmit?: boolean;
+}
+const RequestMusicForm: React.FC<IRequestMusicFormProps> = ({
+  formik,
+  isDetailPage = false,
+  canEditPost = false,
+  isLoadingSubmit = false,
+}) => {
+  const isDisabled = isDetailPage && !canEditPost;
+
+  return (
+    <section className="flex flex-col gap-6 w-full py-6">
+      {!isDetailPage && (
+        <h1 className="text-lg text-sky-700">เพลงที่ต้องการขอ</h1>
+      )}
+      <Input
+        isRequired
+        isReadOnly={isDisabled}
+        label="ชื่อเพลง"
+        name="message"
+        placeholder="ระบุเพลงที่ต้องการให้เปิด"
+        value={formik.values.message}
+        onChange={formik.handleChange}
+      />
+
+      <Input
+        isReadOnly={isDisabled}
+        label="คุณคือใคร"
+        maxLength={20}
+        name="name"
+        placeholder="ถ้าไม่ต้องการระบุชื่อข้ามไปได้เลย"
+        type="text"
+        value={formik.values.name}
+        onChange={formik.handleChange}
+      />
+      <div className="flex gap-4">
+        <Select
+          className="max-w-sm"
+          isDisabled={isDisabled}
+          label="อายุ"
+          placeholder="ไม่จำเป็นต้องระบุ"
+          selectedKeys={[formik.values.age]}
+          onChange={(e) => formik.setFieldValue("age", e.target.value)}
+        >
+          {formOptions.age.map((option) => (
+            <SelectItem key={option.key}>{option.label}</SelectItem>
+          ))}
+        </Select>
+        <Select
+          className="max-w-sm"
+          isDisabled={isDisabled}
+          label="เพศ"
+          placeholder="ไม่จำเป็นต้องระบุ"
+          selectedKeys={[formik.values.gender]}
+          onChange={(e) => formik.setFieldValue("gender", e.target.value)}
+        >
+          {formOptions.gender.map((option) => (
+            <SelectItem key={option.key}>{option.label}</SelectItem>
+          ))}
+        </Select>
+      </div>
+      {!isDisabled && (
+        <div className="space-y-2">
+          <p>เลือกสีของโพส</p>
+          <CirclePicker
+            color={formik.values.postColor}
+            colors={postBackgroundColor}
+            onChange={(color) => formik.setFieldValue("postColor", color.hex)}
+          />
+        </div>
+      )}
+      <PostItCard
+        isYourPost={false}
+        item={{
+          id: "id",
+          postColor: formik.values.postColor,
+          name: formik.values.name,
+          message: formik.values.message,
+          createdAt: formik.values.createdAt,
+        }}
+        width={260}
+        onClickCardItemHandler={() => {}}
+      />
+      <Checkbox
+        isDisabled={isDisabled}
+        isSelected={formik.values.isPublish}
+        onChange={(e) => formik.setFieldValue("isPublish", e.target.checked)}
+      >
+        <span className="text-sm"> ต้องการให้แสดงคำขอในบอร์ด</span>
+      </Checkbox>
+      {!isDisabled && (
+        <Button
+          className="w-full max-w-md mt-5"
+          color="primary"
+          isDisabled={!formik.isValid || formik.values.message === ""}
+          isLoading={isLoadingSubmit}
+          startContent={
+            <svg
+              height="20"
+              viewBox="0 0 1024 1023"
+              width="20"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m896 800l128 223l-224-128l-1-6l-168-167l-152 151q-42 42-95-10V684L126 416l-13 12q-19 20-46.5 20t-47-19.5t-19.5-47T19 334L335 19q20-19 47.5-19t47 19T449 65.5T429 113l-13 13l269 258l179 1q52 52 9 94L722 630l168 168z"
+                fill="currentColor"
+              />
+            </svg>
+          }
+          onPress={() => formik.handleSubmit()}
+        >
+          {!canEditPost ? "ติดคำขอลงในบอร์ด" : "ยืนยันการแก้ไข"}
+        </Button>
+      )}
+    </section>
+  );
+};
+
+export default RequestMusicForm;

--- a/components/icons/MusicNoteIcon.tsx
+++ b/components/icons/MusicNoteIcon.tsx
@@ -1,0 +1,16 @@
+import { JSX, SVGProps } from "react";
+
+export const MusicNoteIcon = (
+  props: JSX.IntrinsicAttributes & SVGProps<SVGSVGElement>
+) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    height="1em"
+    width="1em"
+    {...props}
+  >
+    <path d="M9 3v13.55a4 4 0 1 0 2 3.45V6.15l10-2V14.55a4 4 0 1 0 2 3.45V2.5a1 1 0 0 0-1.25-.97l-12 2.4A1 1 0 0 0 9 4.9V3z" />
+  </svg>
+);

--- a/components/selects/post-type-select.tsx
+++ b/components/selects/post-type-select.tsx
@@ -4,6 +4,7 @@ import { Select, SelectItem } from "@heroui/select";
 import { HourglassDone } from "../icons/HourGlassIcon";
 import { Topic } from "../icons/Topic";
 import { AskubuntuIcon } from "../icons/AskIcon";
+import { MusicNoteIcon } from "../icons/MusicNoteIcon";
 
 import { PostType } from "@/enums/post.enum";
 
@@ -22,6 +23,11 @@ const postTypeOptions = [
     key: PostType.QA,
     label: "ถามคำถาม Q&A",
     icon: <AskubuntuIcon />,
+  },
+  {
+    key: PostType.REQUEST_MUSIC,
+    label: "ขอเพลง",
+    icon: <MusicNoteIcon />,
   },
 ];
 

--- a/config/firebase.ts
+++ b/config/firebase.ts
@@ -35,6 +35,7 @@ const collectionName = {
   users: "users",
   topic: 'topic',
   qa: 'qa',
+  requestMusic: 'request_music',
   tictactoe: 'tictactoe'
 };
 

--- a/enums/post.enum.ts
+++ b/enums/post.enum.ts
@@ -12,6 +12,7 @@ enum PostType {
   ADVICE = "ADVICE",
   TOPIC = "TOPIC",
   QA = "QA",
+  REQUEST_MUSIC = "REQUEST_MUSIC",
 }
 
 enum OrderBy {

--- a/types/index.ts
+++ b/types/index.ts
@@ -35,3 +35,7 @@ export interface TopicFormValues extends BasicInformationFormValues {
 export interface QAFormValues extends BasicInformationFormValues {
   postType: PostType.QA;
 }
+
+export interface RequestMusicFormValues extends BasicInformationFormValues {
+  postType: PostType.REQUEST_MUSIC;
+}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -18,6 +18,8 @@ const getCollectionNameByPostType = (type: PostType) => {
       return collectionName.topic;
     case PostType.QA:
       return collectionName.qa;
+    case PostType.REQUEST_MUSIC:
+      return collectionName.requestMusic;
     default:
       return collectionName.advice;
   }


### PR DESCRIPTION
## Summary
- add `REQUEST_MUSIC` post type
- support Firebase collection for music requests
- add RequestMusicForm component and icons
- expose new board pages
- extend board logic, home page form, and selectors for request music board

## Testing
- `npm run check` *(fails: Cannot find modules)*